### PR TITLE
fixed height map and visibility map

### DIFF
--- a/src/sc2api/sc2_map_info.cpp
+++ b/src/sc2api/sc2_map_info.cpp
@@ -46,7 +46,7 @@ bool SampleImage::GetBit(const Point2DI& point, unsigned char* dst) const {
 
     // Image data is stored with an upper left origin.
     assert(data_.size() == area_.Width() * area_.Height());
-    *dst = data_[point.x + (area_.Height() - 1 - point.y) * area_.Width()];
+    *dst = data_[point.x + point.y * area_.Width()];
     return true;
 }
 
@@ -131,7 +131,7 @@ float HeightMap::TerrainHeight(const Point2DI& point) const {
     if (!height_map_.GetBit(point, &value))
         return 0.0f;
 
-    return -100.0f + 200.0f * static_cast<float>(value) / 255.0f;
+    return (static_cast<float>(value) - 127) / 8.f;
 }
 
 void HeightMap::Dump(const std::string& file_path) const {


### PR DESCRIPTION
I'm not sure if other maps are using the same `SampleImage::GetBit` method, but since Timo mirrored maps that were starting at 0 on the top left, I guess that's better like this now.
Also, RobbyG is not getting the same terrain height values as I get, so we need someone else to test if the formula works because it does for me but not for him.