### PR TITLE
activate raw_affects_selection on release

### DIFF
--- a/include/sc2api/sc2_control_interfaces.h
+++ b/include/sc2api/sc2_control_interfaces.h
@@ -22,7 +22,7 @@ public:
     virtual bool RemoteSaveMap(const void* data, int data_size, std::string remote_path) = 0;
     virtual bool CreateGame(const std::string& map_path, const std::vector<PlayerSetup>& players, bool realtime) = 0;
 
-    virtual bool RequestJoinGame(PlayerSetup setup, const InterfaceSettings& settings, const Ports& ports = Ports()) = 0;
+    virtual bool RequestJoinGame(PlayerSetup setup, const InterfaceSettings& settings, const Ports& ports = Ports(), bool raw_affects_selection = false) = 0;
     virtual bool WaitJoinGame() = 0;
 
     virtual bool RequestLeaveGame() = 0;

--- a/include/sc2api/sc2_coordinator.h
+++ b/include/sc2api/sc2_coordinator.h
@@ -97,6 +97,10 @@ public:
     // \param option The string to be appended to the executable invoke.
     void AddCommandLine(const std::string& option);
 
+    //! When set to true, less actions will be generated because the game will not try to keep your unit selection.
+    //! Useful to reduce the number of actions, but may complicate the debugging process.
+    void SetRawAffectsSelection(bool value);
+
     //! Sets up the bots and whether they are controlled by in-built AI, human or a custom bot.
     // \param participants A vector of player setups for each participant in the game.
     // \sa PlayerSetup

--- a/include/sc2api/sc2_game_settings.h
+++ b/include/sc2api/sc2_game_settings.h
@@ -96,6 +96,7 @@ struct GameSettings {
     std::string map_name;
     std::vector<PlayerSetup> player_setup;
     Ports ports;
+    bool raw_affects_selection = false;
 };
 
 //! Settings for starting a replay.

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -1379,7 +1379,7 @@ public:
     bool Connect(const std::string& address, int port, int timeout_ms) override;
     bool CreateGame(const std::string& map_name, const std::vector<PlayerSetup>& players, bool realtime) override;
 
-    bool RequestJoinGame(PlayerSetup setup, const InterfaceSettings& settings, const Ports& ports = Ports()) override;
+    bool RequestJoinGame(PlayerSetup setup, const InterfaceSettings& settings, const Ports& ports = Ports(), bool raw_affects_selection = false) override;
     bool WaitJoinGame() override;
 
     bool RequestLeaveGame() override;
@@ -1644,7 +1644,7 @@ bool ControlImp::CreateGame(const std::string& map_name, const std::vector<Playe
     return success;
 }
 
-bool ControlImp::RequestJoinGame(PlayerSetup setup, const InterfaceSettings& settings, const Ports& ports) {
+bool ControlImp::RequestJoinGame(PlayerSetup setup, const InterfaceSettings& settings, const Ports& ports, bool raw_affects_selection) {
     observation_imp_->ClearFlags();
 
     is_multiplayer_ = ports.IsValid();
@@ -1676,6 +1676,7 @@ bool ControlImp::RequestJoinGame(PlayerSetup setup, const InterfaceSettings& set
     options->set_score(true);
     options->set_show_cloaked(true);
     options->set_show_burrowed_shadows(true);
+    options->set_raw_affects_selection(raw_affects_selection);	// If true, will not generate a deselect command after sending a command to a unit
 
     if (settings.use_feature_layers) {
         SC2APIProtocol::SpatialCameraSetup* setupProto = options->mutable_feature_layer();

--- a/src/sc2api/sc2_coordinator.cc
+++ b/src/sc2api/sc2_coordinator.cc
@@ -562,7 +562,8 @@ bool CoordinatorImp::JoinGame() {
     for (auto c : agents_) {
         bool game_join_request = c->Control()->RequestJoinGame(game_settings_.player_setup[i++],
             interface_settings_,
-            game_settings_.ports);
+            game_settings_.ports,
+            game_settings_.raw_affects_selection);
 
         if (!game_join_request) {
             std::cerr << "Unable to join game." << std::endl;
@@ -971,6 +972,11 @@ bool Coordinator::HasReplays() const {
 
 void Coordinator::AddCommandLine(const std::string& option) {
     imp_->process_settings_.extra_command_lines.push_back(option);
+}
+
+void Coordinator::SetRawAffectsSelection(bool value)
+{
+    imp_->game_settings_.raw_affects_selection = value;
 }
 
 std::string Coordinator::GetExePath() const {


### PR DESCRIPTION
To allow users to freely select units when debugging, it is activated only on Release.