### PR TITLE
On neutral unit created

### DIFF
--- a/include/sc2api/sc2_client.h
+++ b/include/sc2api/sc2_client.h
@@ -62,6 +62,10 @@ public:
     //!< \param unit The destroyed unit.
     virtual void OnUnitDestroyed(const Unit*) {}
 
+    //!  Called when a neutral unit is created. For example, mineral fields observed for the first time
+    //!< \param unit The observed unit.
+    virtual void OnNeutralUnitCreated(const Unit*) {}
+
     //! Called when a Unit has been created by the player.
     //!< \param unit The created unit.
     virtual void OnUnitCreated(const Unit*) {}
@@ -77,9 +81,14 @@ public:
     //!< \param upgrade The completed upgrade.
     virtual void OnUpgradeCompleted(UpgradeID) {}
 
-    //! Called when the unit in the previous step had a build progress less than 1.0 but is greater than or equal to 1.0 in the current step.
+    //! Called when the unit in the previous step had a build progress less than 1.0 but is greater than or equal to 1.0 in
+    // !the current step.
     //!< \param unit The constructed unit.
     virtual void OnBuildingConstructionComplete(const Unit*) {}
+
+    //! Called when the unit in the current observation has lower health or shields than in the previous observation.
+    //!< \param unit The damaged unit.
+    virtual void OnUnitDamaged(const Unit*) {}
 
     //! Called when a nydus is placed.
     virtual void OnNydusDetected() {}

--- a/include/sc2api/sc2_proto_to_pods.h
+++ b/include/sc2api/sc2_proto_to_pods.h
@@ -17,7 +17,7 @@ typedef MessageResponsePtr<SC2APIProtocol::ResponseGameInfo> ResponseGameInfoPtr
 typedef MessageResponsePtr<SC2APIProtocol::ResponseQuery> ResponseQueryPtr;
 
 bool Convert(const ObservationPtr& observation_ptr, Score& score);
-bool Convert(const ObservationRawPtr& observation_ptr, UnitPool& unit_pool, uint32_t game_loop);
+bool Convert(const ObservationRawPtr& observation_ptr, UnitPool& unit_pool, uint32_t game_loop, uint32_t prev_game_loop);
 bool Convert(const ObservationPtr& observation_ptr, RenderedFrame& render);
 bool Convert(const ResponseGameInfoPtr& response_game_info_ptr, GameInfo& game_info);
 

--- a/include/sc2api/sc2_unit.h
+++ b/include/sc2api/sc2_unit.h
@@ -9,6 +9,7 @@
 #include "sc2_typeenums.h"
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include <string>
 #include <stdint.h>
 
@@ -214,6 +215,17 @@ public:
     void ClearExisting();
     bool UnitExists(Tag tag);
 
+    const Units& GetNewUnits() const noexcept { return units_newly_created_; };
+    const Units& GetUnitsEnteringVision() const noexcept { return units_entering_vision_; };
+    const Units& GetCompletedBuildings() const noexcept { return units_constructed_; };
+    const Units& GetDamagedUnits() const noexcept { return units_damaged_; };
+    const std::unordered_set<const Unit*>& GetIdledUnits() const noexcept { return units_idled_; };
+
+    void AddUnitEnteredVision(const Unit *u) { units_entering_vision_.push_back(u); }
+    void AddCompletedBuilding(const Unit *u) { units_constructed_.push_back(u); }
+    void AddUnitIdled(const Unit *u) { if (u->alliance == Unit::Alliance::Self) units_idled_.insert(u); }
+    void AddUnitDamaged(const Unit *u) { units_damaged_.push_back(u); }
+
 private:
     void IncrementIndex();
 
@@ -222,8 +234,13 @@ private:
     // std::array<Unit, ENTRY_SIZE>
     std::vector<std::vector<Unit> > unit_pool_;
     PoolIndex available_index_;
-    std::unordered_map<Tag, Unit*> tag_to_unit_;
-    std::unordered_map<Tag, Unit*> tag_to_existing_unit_;
+    std::unordered_map<Tag, Unit *> tag_to_unit_;
+    std::unordered_map<Tag, Unit *> tag_to_existing_unit_;
+    Units units_newly_created_;
+    Units units_entering_vision_;
+    Units units_constructed_;
+    Units units_damaged_;
+    std::unordered_set<const Unit*> units_idled_;
 };
 
-}
+        }

--- a/src/sc2api/sc2_unit.cc
+++ b/src/sc2api/sc2_unit.cc
@@ -23,8 +23,10 @@ Unit* UnitPool::CreateUnit(Tag tag) {
 
     std::vector<Unit>& pool = unit_pool_[available_index_.first];
     Unit* unit = &pool[available_index_.second];
+    unit->last_seen_game_loop = 0; // initialization required for OnUnitEnterVision
     tag_to_unit_[tag] = unit;
     tag_to_existing_unit_[tag] = unit;
+    units_newly_created_.push_back(unit);
     IncrementIndex();
     return unit;
 }
@@ -66,6 +68,11 @@ void UnitPool::ForEachExistingUnit(const std::function<void(Unit& unit)>& functo
 
 void UnitPool::ClearExisting() {
     tag_to_existing_unit_.clear();
+    units_newly_created_.clear();
+    units_entering_vision_.clear();
+    units_constructed_.clear();
+    units_idled_.clear();
+    units_damaged_.clear();
 }
 
 bool UnitPool::UnitExists(Tag tag) {


### PR DESCRIPTION
I'm new to this and kind of did this PR the wrong way. I meant to have 3 independent PRs, but instead made them cumulative. 
This PR has 3 features
1) Caches Units experiencing certain events. This was for efficiency and clarity. This is the largest change and is a prerequisite for the other changes
2) Added OnUnitDamaged event, that gets issued when health or shields are weakened compared to the previous observation
3) Added OnNeutralUnitCreated. Effectively the equivalent of OnUnitCreated or OnUnitEntersVision, but for neutral units. Needed because prior to observing a neutral unit, it is a distinct placeholder unit that other units cannot interact with, and it is helpful to know when we can interact with them. 
Let me know if I should break this up into separate requests