### PR TITLE
Make == and != operators const functions for Point2D and Point3D

### DIFF
--- a/include/sc2api/sc2_common.h
+++ b/include/sc2api/sc2_common.h
@@ -33,8 +33,8 @@ struct Point3D {
     Point3D& operator*=(float rhs);
     Point3D& operator/=(float rhs);
 
-    bool operator==(const Point3D& rhs);
-    bool operator!=(const Point3D& rhs);
+    bool operator==(const Point3D& rhs) const;
+    bool operator!=(const Point3D& rhs) const;
 };
 
 Point3D operator+(const Point3D& lhs, const Point3D& rhs);
@@ -70,8 +70,8 @@ struct Point2D {
     Point2D& operator*=(float rhs);
     Point2D& operator/=(float rhs);
 
-    bool operator==(const Point2D& rhs);
-    bool operator!=(const Point2D& rhs);
+    bool operator==(const Point2D& rhs) const;
+    bool operator!=(const Point2D& rhs) const;
 };
 
 Point2D operator+(const Point2D& lhs, const Point2D& rhs);

--- a/src/sc2api/sc2_common.cc
+++ b/src/sc2api/sc2_common.cc
@@ -40,11 +40,11 @@ Point3D& Point3D::operator/=(float rhs) {
     return *this;
 }
 
-bool Point3D::operator==(const Point3D& rhs) {
+bool Point3D::operator==(const Point3D& rhs) const {
     return x == rhs.x && y == rhs.y && z == rhs.z;
 }
 
-bool Point3D::operator!=(const Point3D& rhs) {
+bool Point3D::operator!=(const Point3D& rhs) const {
     return !(*this == rhs);
 }
 
@@ -96,11 +96,11 @@ Point2D& Point2D::operator/=(float rhs) {
     return *this;
 }
 
-bool Point2D::operator==(const Point2D& rhs) {
+bool Point2D::operator==(const Point2D& rhs) const {
     return x == rhs.x && y == rhs.y;
 }
 
-bool Point2D::operator!=(const Point2D& rhs) {
+bool Point2D::operator!=(const Point2D& rhs) const {
     return !(*this == rhs);
 }
 


### PR DESCRIPTION
fix: == and != operators in Point2D and Point3D should be const functions to implement equal_to interface