### PR TITLE
fix: issue where OnUnitDamage event was issued multiple times

### DIFF
--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -209,15 +209,18 @@ bool Convert(const ObservationRawPtr& observation_raw, UnitPool& unit_pool, uint
         unit->is_on_screen = observation_unit.is_on_screen();
         unit->is_blip = observation_unit.is_blip();
 
-        const auto health = observation_unit.health();
-        if (health < unit->health)
+        auto cur_health = observation_unit.health();
+        float damage = unit->health - cur_health;
+        unit->health = cur_health;
+
+        auto cur_shield = observation_unit.shield();
+        float shield_damage = unit->shield - cur_shield;
+        unit->shield = cur_shield;
+
+        if (damage > 0 || shield_damage > 0)
             unit_pool.AddUnitDamaged(unit);
-        unit->health = health;
+
         unit->health_max = observation_unit.health_max();
-        unit->shield = observation_unit.shield();
-        const auto shield = observation_unit.shield();
-        if (shield < unit->shield)
-            unit_pool.AddUnitDamaged(unit);
         unit->shield_max = observation_unit.shield_max();
         unit->energy = observation_unit.energy();
         unit->energy_max = observation_unit.energy_max();


### PR DESCRIPTION
If both shields and health were damaged, then two events were issued. Now, if either shields OR health is damaged an event is issued.  