### PR TITLE
fix: There was an issue with the IsTownHall filter that caused it to …

### DIFF
--- a/src/sc2api/sc2_unit_filters.cc
+++ b/src/sc2api/sc2_unit_filters.cc
@@ -22,7 +22,7 @@ bool IsUnits::operator()(const Unit& unit_) const {
 }
 
 bool IsTownHall::operator()(const Unit& unit_) const {
-    return (unit_.unit_type);
+    return (*this)(unit_.unit_type);
 }
 
 bool IsTownHall::operator()(UNIT_TYPEID type_) const {


### PR DESCRIPTION
…always return true when a unit was passed in.